### PR TITLE
inflate compressed entries using pako

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -48,6 +48,11 @@
         lastModified: new Date(0),
         stream: () => new Response('mjau').body
       })
+      writer.write({
+        lastModified: new Date(0),
+        name: '/folder/',
+        directory: true
+      })
 
       writer.close()
     </script>

--- a/example/reading.html
+++ b/example/reading.html
@@ -44,9 +44,7 @@
         /* 29 */ jszip + 'winrar_utf8_in_name.zip', // fail to read content?
         /* 30 */ jszip + 'zip64.zip', // fail
         /* 31 */ jszip + 'zip64_appended_bytes.zip', // fail
-        /* 32 */ jszip + 'zip64_missing_bytes.zip', // fail
-        /* 33 */ '/test/without-header-size.zip', // fail
-        /* 34 */ '/test/with-header-size.zip' // fail
+        /* 32 */ jszip + 'zip64_missing_bytes.zip' // fail
       ];
 
       let url = urls[11];

--- a/example/reading.html
+++ b/example/reading.html
@@ -12,39 +12,41 @@
 
       const jszip = 'https://cdn.jsdelivr.net/gh/Stuk/jszip/test/ref/';
       const urls = [
-        jszip + 'all-stream.zip', // ok
-        jszip + 'all.7zip.zip', // ok
-        jszip + 'all.windows.zip', // problem reading a compressed image
-        jszip + 'all.zip', // ok
-        jszip + 'all_appended_bytes.zip', // ok
-        jszip + 'all_missing_bytes.zip', // fail as it should
-        jszip + 'all_prepended_bytes.zip', // problem reading
-        jszip + 'archive_comment.zip', // Ok
-        jszip + 'backslash.zip', // ok
-        jszip + 'data_descriptor.zip', // ok
-        jszip + 'deflate-stream.zip',
-        jszip + 'deflate.zip',
-        jszip + 'empty.zip',  // ok
-        jszip + 'encrypted.zip',
-        jszip + 'extra_attributes.zip', // ???
-        jszip + 'folder.zip', // ok
-        jszip + 'image.zip', // ok
-        jszip + 'local_encoding_in_name.zip', // unsolvable?
-        jszip + 'nested.zip', // ok
-        jszip + 'nested_data_descriptor.zip',
-        jszip + 'nested_zip64.zip',
-        jszip + 'pile_of_poo.zip',
-        jszip + 'slashes_and_izarc.zip',
-        jszip + 'store-stream.zip',
-        jszip + 'store.zip',
-        jszip + 'subfolder.zip',
-        jszip + 'text.zip',
-        jszip + 'utf8.zip',
-        jszip + 'utf8_in_name.zip',
-        jszip + 'winrar_utf8_in_name.zip',
-        jszip + 'zip64.zip',
-        jszip + 'zip64_appended_bytes.zip',
-        jszip + 'zip64_missing_bytes.zip'
+        /* 01 */ jszip + 'all-stream.zip', // ok
+        /* 01 */ jszip + 'all.7zip.zip', // ok
+        /* 02 */ jszip + 'all.windows.zip', // ok
+        /* 03 */ jszip + 'all.zip', // ok
+        /* 04 */ jszip + 'all_appended_bytes.zip', // ok
+        /* 05 */ jszip + 'all_missing_bytes.zip', // fail as it should
+        /* 06 */ jszip + 'all_prepended_bytes.zip', // fail
+        /* 07 */ jszip + 'archive_comment.zip', // ok
+        /* 08 */ jszip + 'backslash.zip', // ok
+        /* 09 */ jszip + 'data_descriptor.zip', // ok
+        /* 10 */ jszip + 'deflate-stream.zip', // ok
+        /* 11 */ jszip + 'deflate.zip', // ok
+        /* 12 */ jszip + 'empty.zip',  // ok
+        /* 13 */ jszip + 'encrypted.zip',
+        /* 14 */ jszip + 'extra_attributes.zip', // ???
+        /* 15 */ jszip + 'folder.zip', // ok
+        /* 16 */ jszip + 'image.zip', // ok
+        /* 17 */ jszip + 'local_encoding_in_name.zip', // unsolvable?
+        /* 18 */ jszip + 'nested.zip', // ok
+        /* 19 */ jszip + 'nested_data_descriptor.zip', // ok
+        /* 20 */ jszip + 'nested_zip64.zip', // fail
+        /* 21 */ jszip + 'pile_of_poo.zip', // ok
+        /* 22 */ jszip + 'slashes_and_izarc.zip', // ok
+        /* 23 */ jszip + 'store-stream.zip', // ok
+        /* 24 */ jszip + 'store.zip', // ok
+        /* 25 */ jszip + 'subfolder.zip', // ok
+        /* 26 */ jszip + 'text.zip', // oK
+        /* 27 */ jszip + 'utf8.zip', // ok
+        /* 28 */ jszip + 'utf8_in_name.zip', // ok
+        /* 29 */ jszip + 'winrar_utf8_in_name.zip', // fail to read content?
+        /* 30 */ jszip + 'zip64.zip', // fail
+        /* 31 */ jszip + 'zip64_appended_bytes.zip', // fail
+        /* 32 */ jszip + 'zip64_missing_bytes.zip', // fail
+        /* 33 */ '/test/without-header-size.zip', // fail
+        /* 34 */ '/test/with-header-size.zip' // fail
       ];
 
       let url = urls[11];
@@ -71,9 +73,9 @@
             compressionMethod,
             size,
             compressedSize,
-            ab: await entry.arrayBuffer(),
-            body: await entry.text(),
-            url: URL.createObjectURL(new Blob([await entry.arrayBuffer()], {type: 'd/d'}))
+            ab: entry.encrypted ? null : await entry.arrayBuffer(),
+            body: entry.encrypted ? null : await entry.text(),
+            url: entry.encrypted ? null : URL.createObjectURL(new Blob([await entry.arrayBuffer()], {type: 'd/d'}))
           });
         }
 

--- a/example/reading.html
+++ b/example/reading.html
@@ -47,7 +47,7 @@
         jszip + 'zip64_missing_bytes.zip'
       ];
 
-      let url = urls[30];
+      let url = urls[11];
       console.log(url);
       fetch(url).then(async res => {
         const zip = await res.blob();

--- a/read.js
+++ b/read.js
@@ -37,7 +37,7 @@ class Entry {
     return this.dataView.getUint16(8, true);
   }
   get encrypted() {
-    return (this.bitFlag & 1) === 1;
+    return !!(this.dataView.getUint8(8) & 1)
   }
   get compressionMethod() {
     return this.dataView.getUint16(10, true);
@@ -70,7 +70,7 @@ class Entry {
     return this.dataView.getUint16(38, true);
   }
   get directory() {
-    return (this.externalFileAttributes & 16) === 16;
+    return this.dataView.getUint8(38) === 16;
   }
   get offset() {
     return this.dataView.getUint16(42, true);

--- a/read.js
+++ b/read.js
@@ -1,12 +1,12 @@
-import 'https://cdn.jsdelivr.net/npm/pako@1.0.10/dist/pako.min.js'
-
 class Inflator {
-  constructor() {
+  async start(ctrl) {
+    if (!globalThis.pako) {
+      await import('https://cdn.jsdelivr.net/npm/pako@1.0.10/dist/pako.min.js')
+    }
     this.inflator = new pako.Inflate({ raw: true })
-    this.inflator.onData = chunk => this.ctrl.enqueue(chunk)
+    this.inflator.onData = chunk => ctrl.enqueue(chunk)
     this.done = new Promise(rs => (this.inflator.onEnd = rs))
   }
-  start(ctrl) { this.ctrl = ctrl }
   transform(chunk) { this.inflator.push(chunk) }
   flush() { return this.done }
 }


### PR DESCRIPTION
Well, it was damm easy to use [pako](https://github.com/nodeca/pako/) to inflate something
basically takes the job of from us. pako can "stream" but isn't based on whatwg streams but a [thin wrapper](https://github.com/transcend-io/conflux/blob/88ab40ffac9474d80c710f5cf858b8ee60f65cc7/read.js#L1-L12) around it makes it work with whatwg streams. 

*update:* The async `start` method in the transformer makes it easy to also lazy import pako when needed. Grate thing about it is that getting the stream is still synchronous but it dose not start working until the promise is resolved

(the deflation stuff seems easy too)

it dose increase the dependency quite a bit to this project while also simplifies things a bit.
what i don't like about it is that
- it ain't based on whatwg streams
- it feels quite large?
  - 45kb minified
  - 14kb minified + gzip
- It's bloated with things we don't need (like working with strings)
- it seems [slower](https://github.com/nodeca/pako/issues/136) then [uzip.js](https://github.com/photopea/UZIP.js)

uzip.js seems more lightweight and faster and i would like to get it working with conflux+uzip.js

However it seems more complicated and it wasn't as easy to get it to work when i tested it.
uzip.js can only inflate one segment i think? I think that we have to read some data ourself.
it seems like pako also has a Zstream that reads a entry and parses segments of deflated parts where as uzip.js don't? (not exactly sure what the Zstream do...)

<details>
<summary>Relative part to the specification</summary>

```
5.5 Deflating - Method 8
------------------------

    5.5.1 The Deflate algorithm is similar to the Implode algorithm using
    a sliding dictionary of up to 32K with secondary compression
    from Huffman/Shannon-Fano codes.

    5.5.2 The compressed data is stored in blocks with a header describing
    the block and the Huffman codes used in the data block.  The header
    format is as follows:

       Bit 0: Last Block bit     This bit is set to 1 if this is the last
                                 compressed block in the data.
       Bits 1-2: Block type
          00 (0) - Block is stored - All stored data is byte aligned.
                   Skip bits until next byte, then next word = block 
                   length, followed by the ones compliment of the block
                   length word. Remaining data in block is the stored 
                   data.

          01 (1) - Use fixed Huffman codes for literal and distance codes.
                   Lit Code    Bits             Dist Code   Bits
                   ---------   ----             ---------   ----
                     0 - 143    8                 0 - 31      5
                   144 - 255    9
                   256 - 279    7
                   280 - 287    8

                   Literal codes 286-287 and distance codes 30-31 are 
                   never used but participate in the huffman construction.

          10 (2) - Dynamic Huffman codes.  (See expanding Huffman codes)

          11 (3) - Reserved - Flag a "Error in compressed data" if seen.
```

spec: https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT

I'm no export to the zip architecture, but it don't seems too hard to read all blocks ourself and then use uzip.js?

</details>