### PR TITLE
Use jsbi for BigInt support for write.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "^7.11.0",
+    "jsbi": "^3.1.2",
     "pako": "^1.0.11",
     "web-streams-polyfill": "^3.0.0"
   }

--- a/src/write.js
+++ b/src/write.js
@@ -12,7 +12,6 @@ import JSBI from 'jsbi';
 import Crc32 from './crc.js';
 
 const encoder = new TextEncoder();
-const BigInt = globalThis.BigInt || globalThis.Number;
 
 class ZipTransformer {
   constructor() {


### PR DESCRIPTION
Addressing concerns raised in https://github.com/transcend-io/conflux/issues/13

Uses google's JSBI implementation for BigInt to enable support for wider array of browsers. Babel could be configured to use native implementations on available targets.