### PR TITLE
Trigger build jobs on main branch (migration from "master")

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           extra_args: --source ${{ github.event.pull_request.base.sha || 'HEAD~1' }} --origin ${{ github.event.pull_request.head.sha || 'HEAD' }}
 
   build-to-npm:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs:
       # TODO: https://github.com/transcend-io/penumbra/issues/209 - fix flakiness
@@ -66,7 +66,7 @@ jobs:
         run: yarn npm publish
 
   build-to-github-packages:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs:
       # TODO: https://github.com/transcend-io/penumbra/issues/209 - fix flakiness

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transcend-io/conflux",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Build zip files out of readable streams in the browser",
   "main": "dist/conflux.umd.min.js",
   "jsdelivr": "dist/conflux.umd.min.js",


### PR DESCRIPTION
## Related Issues

- _[none]_

## Public Changelog

- Fixes conflux build CI to run on merge to main branch (it used to be looking conditional on merge to "master" branch)

## Security Implications

_[none]_
